### PR TITLE
Test locking changes

### DIFF
--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/Activator.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/Activator.java
@@ -47,6 +47,7 @@ public class Activator extends AbstractUIPlugin
     private static Logger logger = Logger.getLogger(PLUGIN_ID);
 
     final public static ExecutorService thread_pool = Executors.newCachedThreadPool(new NamedThreadFactory("DataBrowserJobs"));
+    final public static ExecutorService sql_thread_pool = Executors.newSingleThreadExecutor(new NamedThreadFactory("DataBrowserSQL"));
 
     /** Width of the display in pixels. Used to scale negative plot_bins */
     public static int display_pixel_width = 0;
@@ -110,6 +111,12 @@ public class Activator extends AbstractUIPlugin
     public static ExecutorService getThreadPool()
     {
         return thread_pool;
+    }
+
+    /** @return Thread pool */
+    public static ExecutorService getSqlThreadPool()
+    {
+        return sql_thread_pool;
     }
 
     /** Obtain image descriptor from file within plugin.

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/AdapterFactory.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/AdapterFactory.java
@@ -7,12 +7,16 @@
  ******************************************************************************/
 package org.csstudio.trends.databrowser2;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+
 import org.csstudio.csdata.ProcessVariable;
 import org.csstudio.trends.databrowser2.model.ChannelInfo;
 import org.csstudio.trends.databrowser2.model.ModelItem;
 import org.csstudio.trends.databrowser2.model.PlotSamples;
-import org.eclipse.core.runtime.IAdapterFactory;
 import org.diirt.vtype.VType;
+import org.eclipse.core.runtime.IAdapterFactory;
 
 /** Adapt Data Browser model items to CSS PV
  *
@@ -20,6 +24,7 @@ import org.diirt.vtype.VType;
  *
  *  @author Kay Kasemir
  */
+@SuppressWarnings("nls")
 public class AdapterFactory implements IAdapterFactory
 {
     @Override
@@ -60,19 +65,28 @@ public class AdapterFactory implements IAdapterFactory
     private ProcessVariableWithSamples convertToPvWithSamples(final ModelItem item)
     {
         final PlotSamples plot_samples = item.getSamples();
-        final VType[] samples;
-        plot_samples.getLock().lock();
+
         try
         {
-            final int size = plot_samples.size();
-            samples = new VType[size];
-            for (int i=0; i<size; ++i)
-                samples[i] = plot_samples.get(i).getVType();
+            if (! plot_samples.getLock().tryLock(10, TimeUnit.SECONDS))
+                throw new TimeoutException("Cannot lock data for " + item + ": " + plot_samples);
+            try
+            {
+                final int size = plot_samples.size();
+                final VType[] samples = new VType[size];
+                for (int i=0; i<size; ++i)
+                    samples[i] = plot_samples.get(i).getVType();
+                return new ProcessVariableWithSamples(new ProcessVariable(item.getName()), samples);
+            }
+            finally
+            {
+                plot_samples.getLock().unlock();
+            }
         }
-        finally
+        catch (Exception ex)
         {
-            plot_samples.getLock().unlock();
+            e.printStackTrace();
+            return null;
         }
-        return new ProcessVariableWithSamples(new ProcessVariable(item.getName()), samples);
     }
 }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/AdapterFactory.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/AdapterFactory.java
@@ -85,7 +85,7 @@ public class AdapterFactory implements IAdapterFactory
         }
         catch (Exception ex)
         {
-            e.printStackTrace();
+            ex.printStackTrace();
             return null;
         }
     }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/ArchiveFetchJob.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/archive/ArchiveFetchJob.java
@@ -150,7 +150,7 @@ public class ArchiveFetchJob extends Job
                     }
                     // Get samples into array
                     final List<VType> result = new ArrayList<VType>();
-                    while (value_iter.hasNext())
+                    while (value_iter.hasNext() && !cancelled)
                         result.add(value_iter.next());
                     samples += result.size();
                     item.mergeArchivedSamples(the_reader.getServerName(), result);
@@ -246,7 +246,7 @@ public class ArchiveFetchJob extends Job
 
         monitor.beginTask(Messages.ArchiveFetchStart, IProgressMonitor.UNKNOWN);
         final WorkerThread worker = new WorkerThread();
-        final Future<?> done = Activator.getThreadPool().submit(worker);
+        final Future<?> done = Activator.getSqlThreadPool().submit(worker);
         // Poll worker and progress monitor
         long start = System.currentTimeMillis();
         while (!done.isDone())

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/export/ModelSampleIterator.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/export/ModelSampleIterator.java
@@ -41,7 +41,7 @@ public class ModelSampleIterator implements ValueIterator
     /** @param end End time
      */
     public ModelSampleIterator(final ModelItem item, final Instant start,
-            final Instant end)
+            final Instant end) throws Exception
     {
         this.samples = item.getSamples();
         this.end = end;

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/export/ModelSampleIterator.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/export/ModelSampleIterator.java
@@ -8,6 +8,8 @@
 package org.csstudio.trends.databrowser2.export;
 
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.csstudio.archive.reader.ValueIterator;
 import org.csstudio.archive.vtype.VTypeHelper;
@@ -43,7 +45,8 @@ public class ModelSampleIterator implements ValueIterator
     {
         this.samples = item.getSamples();
         this.end = end;
-        samples.getLock().lock();
+        if (! samples.getLock().tryLock(10, TimeUnit.SECONDS))
+            throw new TimeoutException("Cannot lock " + samples);
         try
         {
             // Anything?
@@ -129,7 +132,8 @@ public class ModelSampleIterator implements ValueIterator
             throw new Exception("End of samples"); //$NON-NLS-1$
         // Remember value, prepare the next value
         final VType result = value;
-        samples.getLock().lock();
+        if (! samples.getLock().tryLock(10, TimeUnit.SECONDS))
+            throw new TimeoutException("Cannot lock " + samples);
         try
         {
             ++index;

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/FormulaInput.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/FormulaInput.java
@@ -8,6 +8,8 @@
 package org.csstudio.trends.databrowser2.model;
 
 import org.diirt.vtype.VType;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /** One input to the formula: Model item that provides data, Variable name
  *  for use in the formula
@@ -50,10 +52,11 @@ public class FormulaInput
      *  @see #next()
      *  @return First sample or <code>null</code>
      */
-    public VType first()
+    public VType first() throws Exception
     {
         final PlotSamples samples = item.getSamples();
-        samples.getLock().lock();
+        if (! samples.getLock().tryLock(10, TimeUnit.SECONDS))
+            throw new TimeoutException("Cannot lock " + samples);
         try
         {
             if (samples.size() > 0)
@@ -71,13 +74,14 @@ public class FormulaInput
     /** Iterate over the samples of the input's ModelItem
      *  @return Next value or <code>null</code>
      */
-    public VType next()
+    public VType next() throws Exception
     {
         if (index < 0)
             return null;
         final VType result;
         final PlotSamples samples = item.getSamples();
-        samples.getLock().lock();
+        if (! samples.getLock().tryLock(10, TimeUnit.SECONDS))
+            throw new TimeoutException("Cannot lock " + samples);
         try
         {
             if (index < samples.size())

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/FormulaItem.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/FormulaItem.java
@@ -136,6 +136,7 @@ public class FormulaItem extends ModelItem
     {
         final List<PlotSample> result = new ArrayList<PlotSample>();
         final Display display = ValueFactory.displayNone();
+        try{
         // Prevent changes to formula & inputs
         synchronized (this)
         {
@@ -252,6 +253,10 @@ public class FormulaItem extends ModelItem
                 }
                 result.add(new PlotSample(Messages.Formula, value));
             }
+        }
+        }
+        catch (Exception ex) {
+            ex.printStackTrace();
         }
         // Update PlotSamples
         samples.set(result);

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVItem.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVItem.java
@@ -408,7 +408,8 @@ public class PVItem extends ModelItem implements PVReaderListener<List<VType>>
     /** Add one(!) 'disconnected' sample */
     private void logDisconnected()
     {
-        samples.lockForWriting();
+        if (! samples.lockForWriting())
+            return;
         try
         {
             final int size = samples.size();
@@ -436,7 +437,8 @@ public class PVItem extends ModelItem implements PVReaderListener<List<VType>>
             final List<VType> new_samples)
     {
         final boolean need_refresh;
-        samples.lockForWriting();
+        if (! samples.lockForWriting())
+            return;
         try
         {
             samples.mergeArchivedData(server_name, new_samples);

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVSamples.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVSamples.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.csstudio.archive.vtype.VTypeHelper;
 import org.csstudio.trends.databrowser2.Messages;
 import org.diirt.vtype.AlarmSeverity;
@@ -157,7 +160,8 @@ public class PVSamples extends PlotSamples
     public void mergeArchivedData(final String source,
             final List<VType> result)
     {
-        lockForWriting();
+        if (! lockForWriting())
+            return;
         try
         {
             if (emptyHistoryOnAdd)
@@ -188,7 +192,8 @@ public class PVSamples extends PlotSamples
      */
     public void addLiveSample(final PlotSample sample)
     {
-        lockForWriting();
+        if (! lockForWriting())
+            return;
         try
         {
             // Skip the initial UNDEFINED/Disconnected sample sent by PVManager
@@ -211,7 +216,8 @@ public class PVSamples extends PlotSamples
     /** Delete all samples */
     public void clear()
     {
-        lockForWriting();
+        if (! lockForWriting())
+            return;
         try
         {
             history.clear();
@@ -237,7 +243,16 @@ public class PVSamples extends PlotSamples
      */
     boolean isHistoryRefreshNeeded(final Instant startTime, final Instant endTime)
     {
-        getLock().lock();
+        try
+        {
+            if (! getLock().tryLock(10, TimeUnit.SECONDS))
+                throw new TimeoutException();
+        }
+        catch (Exception ex)
+        {
+            System.out.println("Cannot lock " + this ". Error was: " + ex.getMessage());
+            return false;
+        }
         try
         {
             //if already waiting for history to be loaded, wait on
@@ -290,7 +305,7 @@ public class PVSamples extends PlotSamples
         buf.append("\nLive Buffer: ");
         buf.append(live.toString());
 
-        getLock().lock();
+        if (getLock().tryLock()) {
         try
         {
             final int count = size();
@@ -304,6 +319,7 @@ public class PVSamples extends PlotSamples
         finally
         {
             getLock().unlock();
+        }
         }
     }
 }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVSamples.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PVSamples.java
@@ -250,7 +250,7 @@ public class PVSamples extends PlotSamples
         }
         catch (Exception ex)
         {
-            System.out.println("Cannot lock " + this ". Error was: " + ex.getMessage());
+            System.out.println("Cannot lock " + this + ". Error was: " + ex.getMessage());
             return false;
         }
         try
@@ -306,20 +306,21 @@ public class PVSamples extends PlotSamples
         buf.append(live.toString());
 
         if (getLock().tryLock()) {
-        try
-        {
-            final int count = size();
-            if (count != getRawSize())
+            try
             {
-                buf.append("\nContinuation to 'now':\n");
-                buf.append("     " + get(count-1));
+                final int count = size();
+                if (count != getRawSize())
+                {
+                    buf.append("\nContinuation to 'now':\n");
+                    buf.append("     " + get(count-1));
+                }
             }
-            return buf.toString();
+            finally
+            {
+                getLock().unlock();
+            }
         }
-        finally
-        {
-            getLock().unlock();
-        }
-        }
+        
+        return buf.toString();
     }
 }

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PlotSamples.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/model/PlotSamples.java
@@ -13,6 +13,9 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.csstudio.swt.rtplot.data.PlotDataProvider;
 
 /** Base for classes that hold plot samples
@@ -30,9 +33,17 @@ abstract public class PlotSamples implements PlotDataProvider<Instant>
     final protected AtomicBoolean have_new_samples = new AtomicBoolean();
 
     /** Lock for writing */
-    public void lockForWriting()
+    public boolean lockForWriting()
     {
-        lock.writeLock().lock();
+        try {
+            if (lock.writeLock().tryLock(10, TimeUnit.SECONDS)) {
+                return true;
+            }
+            throw new TimeoutException();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return false;
     }
 
     /** Un-lock after writing */

--- a/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/sampleview/SampleTableContentProvider.java
+++ b/applications/databrowser/databrowser-plugins/org.csstudio.trends.databrowser2/src/org/csstudio/trends/databrowser2/sampleview/SampleTableContentProvider.java
@@ -13,6 +13,8 @@ import org.csstudio.trends.databrowser2.model.PlotSamples;
 import org.eclipse.jface.viewers.ILazyContentProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /** Provide PlotSample items for table with type SWT.VIRTUAL.
  *  TableViewerInput is a ModelItem


### PR DESCRIPTION
Test new locking changes.

Some of these changes come from the equivalent changes at `https://github.com/kasemir/org.csstudio.display.builder/commit/c6e71d784f3a981cf70d5f5b898d59d5db2a5214`, however that is on `databrowser3` (JavaFX) rather than `databrowser2` which we use.

The biggest functional change is to use a `singleThreadExecutor` rather than a `cachedThreadPool` to do the actual SQL queries. This keeps all of the queries on one thread which in turn keeps JDBC happy.

See https://github.com/ISISComputingGroup/IBEX/issues/4722

Note: once you have merged this pull request you also need to update the submodule in https://github.com/ISISComputingGroup/isis_css_top