### PR TITLE
Refactor to be thread-safe

### DIFF
--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/model/ArchiveChannel.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/model/ArchiveChannel.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Iterator;
 
 import org.csstudio.archive.engine.Activator;
 import org.csstudio.archive.engine.ThrottledLogger;
@@ -175,10 +176,10 @@ abstract public class ArchiveChannel extends PVListenerAdapter
         return groups.size();
     }
 
-    /** @return One Group to which this channel belongs */
-    final public ArchiveGroup getGroup(final int index)
+    /** @return Iterator over all groups */
+    final public Iterator<ArchiveGroup> getAllGroupsIter()
     {
-        return groups.get(index);
+        return groups.iterator();
     }
 
     /** Tell channel that it belogs to group */

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/model/ArchiveGroup.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/model/ArchiveGroup.java
@@ -8,6 +8,7 @@
 package org.csstudio.archive.engine.model;
 
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Iterator;
 
 /** A group of archived channels.
  *  Each channel is in exactly one group.
@@ -87,14 +88,14 @@ public class ArchiveGroup
     {
         return channels.size();
     }
-
-    /** @return Channel
+	
+	/** @return An iterator over all available channels.
      *  @param i Channel index
      *  @see #getChannelCount()
      */
-    final public ArchiveChannel getChannel(final int i)
+    final public Iterator<ArchiveChannel> getAllChannelsIter()
     {
-        return channels.get(i);
+        return channels.iterator();
     }
 
     /** Locate a channel by name.

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/AbstractMainResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/AbstractMainResponse.java
@@ -11,6 +11,9 @@ import java.net.InetAddress;
 
 import org.csstudio.archive.engine.model.ArchiveGroup;
 import org.csstudio.archive.engine.model.EngineModel;
+import org.csstudio.archive.engine.model.ArchiveChannel;
+
+import java.util.Iterator;
 
 /** Provide web page with engine overview.
  *  @author Kay Kasemir
@@ -45,20 +48,23 @@ public abstract class AbstractMainResponse extends AbstractResponse
     }
 
     protected void updateChannelCount() {
-        final int group_count = model.getGroupCount();
-        int connect_count = 0;
-        totalChannelCount = 0;
-        for (int i=0; i<group_count; ++i)
-        {
-            final ArchiveGroup group = model.getGroup(i);
-            final int channel_count = group.getChannelCount();
-            for (int j=0; j<channel_count; ++j)
-            {
-                if (group.getChannel(j).isConnected())
-                    ++connect_count;
-            }
-            totalChannelCount += channel_count;
-        }
+		final Iterator<ArchiveGroup> groupsIter = model.getAllGroupsIter();
+		int connect_count = 0;
+		totalChannelCount = 0;
+		while (groupsIter.hasNext())
+		{
+			final ArchiveGroup group = groupsIter.next();
+			final Iterator<ArchiveChannel> iter = group.getAllChannelsIter();
+			long channel_count = 0;
+			while (iter.hasNext())
+			{
+				if (iter.next().isConnected()) {
+					++connect_count;
+				}
+				++channel_count;
+			}
+			totalChannelCount += channel_count;
+		}
 
         disconnectCount = totalChannelCount - connect_count;
     }

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/ChannelListResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/ChannelListResponse.java
@@ -18,6 +18,8 @@ import org.csstudio.archive.engine.model.ArchiveGroup;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with list of channels (by pattern).
  *  @author Kay Kasemir
  */
@@ -57,20 +59,24 @@ public class ChannelListResponse extends AbstractResponse
             Messages.HTTP_LastArchivedValue,
         });
 
-        for (int i=0; i<model.getChannelCount(); ++i)
+		final Iterator<ArchiveChannel> channelsIter = model.getAllChannelsIter();
+        while (channelsIter.hasNext())
         {
-            final ArchiveChannel channel = model.getChannel(i);
+            final ArchiveChannel channel = channelsIter.next();
             // Filter by channel name pattern
             if (!pattern.matcher(channel.getName()).matches())
                 continue;
             final StringBuilder groups = new StringBuilder();
-            for (int g=0; g<channel.getGroupCount(); ++g)
+			final Iterator<ArchiveGroup> groupsIter = channel.getAllGroupsIter();
+			int g = 0;
+            while (groupsIter.hasNext())
             {
                 if (g > 0)
                     groups.append(", ");
-                final ArchiveGroup group = channel.getGroup(i);
+                final ArchiveGroup group = groupsIter.next();
                 groups.append(HTMLWriter.makeLink(
                             "group?name=" + group.getName(), group.getName()));
+				g++;
             }
             html.tableLine(new String[]
             {

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLChannelResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLChannelResponse.java
@@ -12,10 +12,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.csstudio.archive.engine.Messages;
 import org.csstudio.archive.engine.model.ArchiveGroup;
+import org.csstudio.archive.engine.model.ArchiveChannel;
 import org.csstudio.archive.engine.model.BufferStats;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.model.SampleBuffer;
 import org.csstudio.archive.engine.server.AbstractChannelResponse;
+
+import java.util.Iterator;
 
 /** Provide web page with detail for one channel in HTML.
  *  @author Kay Kasemir
@@ -107,9 +110,10 @@ public class HTMLChannelResponse extends AbstractChannelResponse
             Messages.HTTP_Group,
             Messages.HTTP_Enabled,
         });
-        for (int i=0; i<channel.getGroupCount(); ++i)
+		Iterator<ArchiveGroup> iter = channel.getAllGroupsIter();
+        while (iter.hasNext())
         {
-            final ArchiveGroup group = channel.getGroup(i);
+            final ArchiveGroup group = iter.next();
             html.tableLine(new String[]
             {
                 HTMLWriter.makeLink("group?name=" + group.getName(), group.getName()),

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLDisconnectedResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLDisconnectedResponse.java
@@ -16,6 +16,8 @@ import org.csstudio.archive.engine.model.ArchiveGroup;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with list of disconnected channels in HTML
  *  @author Kay Kasemir
  */
@@ -34,15 +36,15 @@ public class HTMLDisconnectedResponse extends AbstractResponse
         final HTMLWriter html = new HTMLWriter(resp, Messages.HTTP_DisconnectedTitle);
         html.openTable(1, new String[] { "#", Messages.HTTP_Channel, Messages.HTTP_Group });
 
-        final int group_count = model.getGroupCount();
+        final Iterator<ArchiveGroup> groupsIter = model.getAllGroupsIter();
         int disconnected = 0;
-        for (int i=0; i<group_count; ++i)
+        while (groupsIter.hasNext())
         {
-            final ArchiveGroup group = model.getGroup(i);
-            final int channel_count = group.getChannelCount();
-            for (int j=0; j<channel_count; ++j)
+            final ArchiveGroup group = groupsIter.next();
+            final Iterator<ArchiveChannel> channelsIter = group.getAllChannelsIter();
+            while (channelsIter.hasNext())
             {
-                final ArchiveChannel channel = group.getChannel(j);
+                final ArchiveChannel channel = channelsIter.next();
                 if (channel.isConnected())
                     continue;
                 ++disconnected;

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLGroupResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLGroupResponse.java
@@ -17,6 +17,8 @@ import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.model.SampleBuffer;
 import org.csstudio.archive.engine.server.AbstractGroupResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with detail for one group in HTML.
  *  @author Kay Kasemir
  */
@@ -79,10 +81,10 @@ public class HTMLGroupResponse extends AbstractGroupResponse
             Messages.HTTP_QueueCapacity,
             Messages.HTTP_QueueOverruns,
         });
-        final int channel_count = group.getChannelCount();
-        for (int j=0; j<channel_count; ++j)
+        final Iterator<ArchiveChannel> channelsIter = group.getAllChannelsIter();
+        while (channelsIter.hasNext())
         {
-            final ArchiveChannel channel = group.getChannel(j);
+            final ArchiveChannel channel = channelsIter.next();
             final String connected = channel.isConnected()
             ? Messages.HTTP_Connected : HTMLWriter.makeRedText(Messages.HTTP_Disconnected);
             final SampleBuffer buffer = channel.getSampleBuffer();

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLGroupsResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/html/HTMLGroupsResponse.java
@@ -17,6 +17,8 @@ import org.csstudio.archive.engine.model.BufferStats;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with basic info for all the groups in HTML.
  *  @author Kay Kasemir
  */
@@ -45,22 +47,23 @@ public class HTMLGroupsResponse extends AbstractResponse
             Messages.HTTP_QueueAvg,
             Messages.HTTP_QueueMax,
         });
-        final int group_count = model.getGroupCount();
+        final Iterator<ArchiveGroup> groupsIter = model.getAllGroupsIter();
         int total_channels = 0;
         int total_connect = 0;
         long total_received_values = 0;
         // Per group lines
-        for (int i=0; i<group_count; ++i)
+        while (groupsIter.hasNext())
         {
-            final ArchiveGroup group = model.getGroup(i);
-            final int channel_count = group.getChannelCount();
+            final ArchiveGroup group = groupsIter.next();
+            final Iterator<ArchiveChannel> channelsIter = group.getAllChannelsIter();
             int connect_count = 0;
             double queue_avg = 0;
             int queue_max = 0;
             long received_values = 0;
-            for (int j=0; j<channel_count; ++j)
+			int channel_count = 0;
+            while (channelsIter.hasNext())
             {
-                final ArchiveChannel channel = group.getChannel(j);
+                final ArchiveChannel channel = channelsIter.next();
                 if (channel.isConnected())
                     ++connect_count;
                 received_values += channel.getReceivedValues();
@@ -69,6 +72,8 @@ public class HTMLGroupsResponse extends AbstractResponse
                 queue_avg += stats.getAverageSize();
                 if (queue_max < stats.getMaxSize())
                     queue_max = stats.getMaxSize();
+				
+				channel_count++;
             }
             if (channel_count > 0)
                 queue_avg /= channel_count;

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONChannelResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONChannelResponse.java
@@ -15,6 +15,8 @@ import org.csstudio.archive.engine.model.ArchiveGroup;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractChannelResponse;
 
+import java.util.Iterator;
+
 /** Provide JSON with detail for one channel.
  *  @author Dominic Oram
  */
@@ -38,9 +40,10 @@ public class JSONChannelResponse extends AbstractChannelResponse
 
         JSONObject groups = new JSONObject();
 
-        for (int i=0; i<channel.getGroupCount(); ++i)
+		Iterator<ArchiveGroup> iter = channel.getAllGroupsIter();
+        while (iter.hasNext())
         {
-            final ArchiveGroup group = channel.getGroup(i);
+            final ArchiveGroup group = iter.next();
             groups.writeObjectEntry(group.getName(), group.isEnabled());
         }
 

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONDisconnectedResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONDisconnectedResponse.java
@@ -16,6 +16,8 @@ import org.csstudio.archive.engine.model.ArchiveGroup;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with list of disconnected channels in JSON
  *  @author Dominic Oram
  */
@@ -33,27 +35,28 @@ public class JSONDisconnectedResponse extends AbstractResponse
     {
         final JSONRoot json = new JSONRoot(resp);
         JSONList disconnected = new JSONList();
+		
+		final Iterator<ArchiveGroup> groupsIter = model.getAllGroupsIter();
 
-        final int group_count = model.getGroupCount();
-        for (int i=0; i<group_count; ++i)
-        {
-            final ArchiveGroup group = model.getGroup(i);
-            final int channel_count = group.getChannelCount();
-            for (int j=0; j<channel_count; ++j)
-            {
-                final ArchiveChannel channel = group.getChannel(j);
-                if (channel.isConnected())
-                    continue;
+		while (groupsIter.hasNext())
+		{
+			final ArchiveGroup group = groupsIter.next();
+			final Iterator<ArchiveChannel> channelsIter = group.getAllChannelsIter();
+			while (channelsIter.hasNext())
+			{
+				final ArchiveChannel channel = channelsIter.next();
+				if (channel.isConnected())
+					continue;
 
-                JSONObject JSONchannel = new JSONObject();
+				JSONObject JSONchannel = new JSONObject();
 
-                JSONchannel.writeObjectEntry(Messages.HTTP_Channel, channel.getName());
-                JSONchannel.writeObjectEntry(Messages.HTTP_Group, group.getName());
-                disconnected.addObjectToList(JSONchannel);
+				JSONchannel.writeObjectEntry(Messages.HTTP_Channel, channel.getName());
+				JSONchannel.writeObjectEntry(Messages.HTTP_Group, group.getName());
+				disconnected.addObjectToList(JSONchannel);
 
-            }
-        }
-        json.writeObjectEntry(Messages.HTTP_DisconnectedTitle, disconnected);
-        json.close();
+			}
+		}
+		json.writeObjectEntry(Messages.HTTP_DisconnectedTitle, disconnected);
+		json.close();
     }
 }

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONGroupResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONGroupResponse.java
@@ -15,6 +15,8 @@ import org.csstudio.archive.engine.model.ArchiveChannel;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractGroupResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with detail for one group in JSON.
  *  @author Dominic Oram
  */
@@ -46,10 +48,10 @@ public class JSONGroupResponse extends AbstractGroupResponse
         // JSON object of all channels in the group
         JSONList channels = new JSONList();
 
-        final int channel_count = group.getChannelCount();
-        for (int j=0; j<channel_count; ++j)
+        final Iterator<ArchiveChannel> iter = group.getAllChannelsIter();
+        while (iter.hasNext())
         {
-            final ArchiveChannel channel = group.getChannel(j);
+            final ArchiveChannel channel = iter.next();
 
             channels.addObjectToList(JSONHelper.createChannelObject(channel));
         }

--- a/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONGroupsResponse.java
+++ b/applications/archive/archive-plugins/org.csstudio.archive.engine/src/org/csstudio/archive/engine/server/json/JSONGroupsResponse.java
@@ -17,6 +17,8 @@ import org.csstudio.archive.engine.model.BufferStats;
 import org.csstudio.archive.engine.model.EngineModel;
 import org.csstudio.archive.engine.server.AbstractResponse;
 
+import java.util.Iterator;
+
 /** Provide web page with basic info for all the groups in JSON.
  *  @author Dominic Oram
  */
@@ -36,22 +38,23 @@ public class JSONGroupsResponse extends AbstractResponse
 
         JSONList groups = new JSONList();
 
-        final int group_count = model.getGroupCount();
+        final Iterator<ArchiveGroup> groupsIter = model.getAllGroupsIter();
         int total_channels = 0;
         int total_connect = 0;
         long total_received_values = 0;
         // Per group objects
-        for (int i=0; i<group_count; ++i)
+        while (groupsIter.hasNext())
         {
-            final ArchiveGroup group = model.getGroup(i);
-            final int channel_count = group.getChannelCount();
+            final ArchiveGroup group = groupsIter.next();
+            final Iterator<ArchiveChannel> channelsIter = group.getAllChannelsIter();
             int connect_count = 0;
             double queue_avg = 0;
             int queue_max = 0;
             long received_values = 0;
-            for (int j=0; j<channel_count; ++j)
+			long channel_count = 0;
+            while (channelsIter.hasNext())
             {
-                final ArchiveChannel channel = group.getChannel(j);
+                final ArchiveChannel channel = channelsIter.next();
                 if (channel.isConnected())
                     ++connect_count;
                 received_values += channel.getReceivedValues();
@@ -60,6 +63,8 @@ public class JSONGroupsResponse extends AbstractResponse
                 queue_avg += stats.getAverageSize();
                 if (queue_max < stats.getMaxSize())
                     queue_max = stats.getMaxSize();
+				
+				channel_count++;
             }
             if (channel_count > 0)
                 queue_avg /= channel_count;


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/7470

The error in the ticket looks to be caused by non thread-safe access.

| Thread 1 | Thread 2 |
| --- | --- |
| `var count = getChannelCount()` | - |
| `for(int i=0; i<count; ++i) {` | - |
|  - | `channels = <new smaller list>` |
| `getChannel(i)` (boom) | - |

I've refactored it to use thread-safe iterators over `CopyOnWriteArrayList` in one case, and iterators over an explicit copy of an `ArrayList` in another similar case. Both of these approaches should be thread-safe against the scenario described above, which looks to be the only possible cause of the stack trace seen in the ticket.

---

Unfortunately I wasn't able to find a way to reliably reproduce the original issue in order to write tests for it. My attempt to reproduce was:
- Set up config 1 with 250 blocks
- Set up config 2 with 150 blocks (to maximise amount of time spent in the `for` loop above)
- Switch from config 1 to config 2 while making a large number of requests to the archive engine webserver - in order to try to be in the `for` loop when the channels get changed over.

However this workflow didn't seem to be able to reproduce the exact error in the ticket.

---

To test:
- Build this branch of CSS
- Stop ibex server
- Copy the `.zip`s from `isis_css_top\cs-studio\product\repository\target\products` to `EPICS\ICP_Binaries\css`
- Run `setup_css.bat` in `EPICS\css\master`
- Restart IBEX server
- Verify archivers still work as before (http://localhost:4813/groups and http://localhost:4812/groups)
- Verify by code-review that the new code is thread-safe against the condition described above, and that you agree with my analysis that the stack trace in the ticket can only be caused by this type of threading condition.