### PR TITLE
Ticket_8699: Show alarm trigger limits

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
@@ -9,14 +9,15 @@ Bundle-Description: BEAST library: Alarm model, ...
 Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.help,
+ org.diirt.datasource;bundle-version="3.1.8",
  org.csstudio.csdata;bundle-version="3.0.0",
  org.csstudio.apputil;bundle-version="1.1.2",
  org.csstudio.platform.utility.jms;bundle-version="1.1.3",
  org.csstudio.platform.utility.rdb;bundle-version="1.6.0",
  org.csstudio.logging;bundle-version="3.1.0",
  org.csstudio.security;bundle-version="1.0.0",
- org.diirt.util;bundle-version="3.1.2",
- org.diirt.vtype;bundle-version="3.1.2"
+ org.diirt.util;bundle-version="3.1.8",
+ org.diirt.vtype;bundle-version="3.1.8"
 Export-Package: org.csstudio.alarm.beast,
  org.csstudio.alarm.beast.client,
  org.csstudio.alarm.beast.ui.clientmodel

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
@@ -9,15 +9,15 @@ Bundle-Description: BEAST library: Alarm model, ...
 Require-Bundle: org.junit;bundle-version="4.8.2",
  org.eclipse.core.runtime,
  org.eclipse.help,
- org.diirt.datasource;bundle-version="3.1.8",
+ org.diirt.datasource;bundle-version="3.1.2",
  org.csstudio.csdata;bundle-version="3.0.0",
  org.csstudio.apputil;bundle-version="1.1.2",
  org.csstudio.platform.utility.jms;bundle-version="1.1.3",
  org.csstudio.platform.utility.rdb;bundle-version="1.6.0",
  org.csstudio.logging;bundle-version="3.1.0",
  org.csstudio.security;bundle-version="1.0.0",
- org.diirt.util;bundle-version="3.1.8",
- org.diirt.vtype;bundle-version="3.1.8"
+ org.diirt.util;bundle-version="3.1.2",
+ org.diirt.vtype;bundle-version="3.1.2"
 Export-Package: org.csstudio.alarm.beast,
  org.csstudio.alarm.beast.client,
  org.csstudio.alarm.beast.ui.clientmodel

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
@@ -10,7 +10,8 @@ package org.csstudio.alarm.beast.client;
 import java.io.PrintWriter;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -59,34 +60,63 @@ public class AlarmTreePV extends AlarmTreeLeaf
 
     private volatile String value = null;
 	
+    /**
+     * Thread pool for Alarms limit PV info.
+     */
+    private static final ExecutorService PVINFO_THREADPOOL = Executors.newCachedThreadPool();
+    
 	/**
 	 * Thread-safe PV reader for the limit PVs. For each interesting PV limit an
 	 * instance is created and a thread initiated for the listener.
 	 */
-	private class PV {
-		private final ExecutorService PVINFO_THREADPOOL = Executors.newCachedThreadPool();
-
+	private static class PV {
+		/** Name of the PV' */
 		final String pvName;
+		
+		/** PV reader for this PV */
         PVReader<VType> reader;
-        volatile String pvValue = "UNKONWN";
+        
+        /** Value of the PV, updated by the listener */
+        volatile String pvValue = Messages.Unknown;
+        
+        /** Listener for the PV reader. It attaches to the PV Manager to update the reader */
         private PVReaderListener<VType> listener;
         
+        /** Constructor for PV */
         PV(String pvName) {	
             this.pvName = pvName;
 
             Future<?> result = PVINFO_THREADPOOL.submit(new Runnable() {
     			@Override
     			public void run() {
+    				// Set the thread name for easier debugging. Not using custom factory because 
+    				// there is no easy way to set the PV name in a custom factory (eg allows thread count).
+    				Thread.currentThread().setName(String.format("AlarmTreePV_PVInfo-%s", pvName));
     				listener = new PVReaderListener<VType>() {
     					@Override
     					public synchronized void pvChanged(PVReaderEvent<VType> evt) {
-    						try {   							
-    							if (reader != null && evt.isValueChanged() && reader.isConnected()) {
-    								pvValue = reader.getValue().toString();
+    						try {
+    							if (evt.isExceptionChanged()) {
+    								pvValue = Messages.Unknown;
+    							}
+    							if (reader != null) {
+    								boolean isConnected = reader.isConnected();
+        							if (evt.isConnectionChanged() && !isConnected) {
+        								pvValue = Messages.Unknown;
+        							}
+        							if (evt.isValueChanged() && isConnected) {
+        					        	var value = reader.getValue();
+        					            if (value instanceof VNumber) {
+        					                pvValue = ((VNumber) value).getValue().toString();
+        					                Activator.getLogger().log(Level.INFO, "PV Value: " + pvValue);
+        					            } else {
+        					            	pvValue = value.toString();
+        					            	Activator.getLogger().log(Level.INFO, "PV Value (Not numeric): " + pvValue);
+        					            }
+        							}
     							}
     						} catch (RuntimeException e) {
 								Activator.getLogger().log(Level.SEVERE, "Error reading PV: " + pvName, e);
-								e.printStackTrace();
 							}
     					}
     			    };
@@ -103,30 +133,19 @@ public class AlarmTreePV extends AlarmTreeLeaf
     			result.get();
     		} catch (Exception e) {
     		    Activator.getLogger().log(Level.SEVERE, "Error setting up PV: " + pvName, e);
-    		    e.printStackTrace();
     		}
         }
 
         /** Get the value of this PV */
         String getValue() {
-            if (reader != null && reader.getValue() instanceof VNumber) {
-            	VNumber number = (VNumber) reader.getValue();
-                this.pvValue = number.getValue().toString();
-            }
             return pvValue;
-        }
-
-        void dispose() {
-            if (reader != null && !reader.isClosed()) {
-                reader.close();
-            }
         }
     }
 
 	/**
 	 * Store for limit PVs for LOW, LOLO, HIGH, HIHI.
 	 */
-	private final Map<String, PV> limits = new HashMap<>();
+	private final Map<String, PV> limits = new LinkedHashMap<>();
     
     /** Initialize
      *  @param parent Parent component in hierarchy
@@ -393,9 +412,9 @@ public class AlarmTreePV extends AlarmTreeLeaf
 	 * Set up the limit PVs for LOW, LOLO, HIGH, HIHI.
 	 */
 	private void setLimitDetailsPV() {
-		String[] keys = { "LOW", "LOLO", "HIGH", "HIHI" };
+		final List<String> keys = Arrays.asList("LOLO", "LOW", "HIGH", "HIHI");
 		try {
-			Arrays.stream(keys).forEach(k -> {
+			keys.stream().forEach(k -> {
 				PV pv = limits.get(k);
 				if (pv == null) {
 					limits.put(k, new PV(getName() + "." + k));
@@ -403,8 +422,6 @@ public class AlarmTreePV extends AlarmTreeLeaf
 			});
 		} catch (Exception e) {
 			Activator.getLogger().log(Level.SEVERE, "Error setting limit PVs for " + getName() + ": ", e);
-			System.err.println("Error setting limit PVs for " + getName() + ": " + e.getMessage());
-			e.printStackTrace();
 		}
 	}
 }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
@@ -9,12 +9,30 @@ package org.csstudio.alarm.beast.client;
 
 import java.io.PrintWriter;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
 
+import org.csstudio.alarm.beast.Activator;
 import org.csstudio.alarm.beast.Messages;
 import org.csstudio.alarm.beast.SeverityLevel;
 import org.csstudio.alarm.beast.XMLTags;
 import org.csstudio.apputil.xml.XMLWriter;
 import org.eclipse.osgi.util.NLS;
+
+import org.diirt.datasource.PVManager;
+import org.diirt.datasource.PVReader;
+import org.diirt.datasource.PVReaderEvent;
+import org.diirt.datasource.PVReaderListener;
+import org.diirt.datasource.ExpressionLanguage;
+import org.diirt.vtype.VType;
+import org.diirt.vtype.VNumber;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 
 /** Leaf item in the alarm configuration tree which refers to a PV,
  *  tracking the current and alarm state, value, timestamp info
@@ -24,6 +42,7 @@ import org.eclipse.osgi.util.NLS;
 public class AlarmTreePV extends AlarmTreeLeaf
 {
     private static final long serialVersionUID = 5262966990320748429L;
+	private static final String SEPARATOR = "  |  ";
     private volatile boolean enabled = true;
     private volatile boolean latching = true;
     private volatile boolean annunciating = false;
@@ -39,7 +58,76 @@ public class AlarmTreePV extends AlarmTreeLeaf
     private volatile String current_message = SeverityLevel.OK.getDisplayName();
 
     private volatile String value = null;
+	
+	/**
+	 * Thread-safe PV reader for the limit PVs. For each interesting PV limit an
+	 * instance is created and a thread initiated for the listener.
+	 */
+	private class PV {
+		private final ExecutorService PVINFO_THREADPOOL = Executors.newCachedThreadPool();
 
+		final String pvName;
+        PVReader<VType> reader;
+        volatile String pvValue = "UNKONWN";
+        private PVReaderListener<VType> listener;
+        
+        PV(String pvName) {	
+            this.pvName = pvName;
+
+            Future<?> result = PVINFO_THREADPOOL.submit(new Runnable() {
+    			@Override
+    			public void run() {
+    				listener = new PVReaderListener<VType>() {
+    					@Override
+    					public synchronized void pvChanged(PVReaderEvent<VType> evt) {
+    						try {   							
+    							if (reader != null && evt.isValueChanged() && reader.isConnected()) {
+    								pvValue = reader.getValue().toString();
+    							}
+    						} catch (RuntimeException e) {
+								Activator.getLogger().log(Level.SEVERE, "Error reading PV: " + pvName, e);
+								e.printStackTrace();
+							}
+    					}
+    			    };
+    			    
+    			    reader = PVManager
+    						.read(ExpressionLanguage.channel(pvName, VType.class, VType.class))
+    						.readListener(listener)
+    						.notifyOn(PVINFO_THREADPOOL)
+    		                .maxRate(Duration.ofMillis(100));
+    			}
+    		});
+    		
+    		try {
+    			result.get();
+    		} catch (Exception e) {
+    		    Activator.getLogger().log(Level.SEVERE, "Error setting up PV: " + pvName, e);
+    		    e.printStackTrace();
+    		}
+        }
+
+        /** Get the value of this PV */
+        String getValue() {
+            if (reader != null && reader.getValue() instanceof VNumber) {
+            	VNumber number = (VNumber) reader.getValue();
+                this.pvValue = number.getValue().toString();
+            }
+            return pvValue;
+        }
+
+        void dispose() {
+            if (reader != null && !reader.isClosed()) {
+                reader.close();
+            }
+        }
+    }
+
+	/**
+	 * Store for limit PVs for LOW, LOLO, HIGH, HIHI.
+	 */
+	private final Map<String, PV> limits = new HashMap<>();
+    
     /** Initialize
      *  @param parent Parent component in hierarchy
      *  @param name PV name
@@ -49,6 +137,7 @@ public class AlarmTreePV extends AlarmTreeLeaf
             final String name, final int id)
     {
         super(parent, name, id);
+		setLimitDetailsPV();
     }
 
     /** {@inheritDoc} */
@@ -73,7 +162,7 @@ public class AlarmTreePV extends AlarmTreeLeaf
                 getDelay(),
                 getCurrentSeverity().getDisplayName(),
                 getCurrentMessage()
-            });
+            }) + "\n" + getLimitDetails();
     }
 
     /** @return Current severity */
@@ -287,4 +376,35 @@ public class AlarmTreePV extends AlarmTreeLeaf
                     getCurrentMessage()
                 });
     }
+
+    /**
+     * Get the details of the LOW/HIGH etc limits set for this PV. 
+     * @return
+     */
+	private String getLimitDetails() {
+		final StringBuilder limitDetails = new StringBuilder();
+		limits.forEach((key, pv) -> {
+			limitDetails.append(key).append(": ").append(pv.getValue()).append(SEPARATOR);
+		});
+		return limitDetails.toString().trim();
+	}
+
+	/**
+	 * Set up the limit PVs for LOW, LOLO, HIGH, HIHI.
+	 */
+	private void setLimitDetailsPV() {
+		String[] keys = { "LOW", "LOLO", "HIGH", "HIHI" };
+		try {
+			Arrays.stream(keys).forEach(k -> {
+				PV pv = limits.get(k);
+				if (pv == null) {
+					limits.put(k, new PV(getName() + "." + k));
+				}
+			});
+		} catch (Exception e) {
+			Activator.getLogger().log(Level.SEVERE, "Error setting limit PVs for " + getName() + ": ", e);
+			System.err.println("Error setting limit PVs for " + getName() + ": " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
 }


### PR DESCRIPTION
### Description of work
Addresses the [ticket](https://github.com/ISISComputingGroup/IBEX/issues/8699).


### Acceptance criteria
- [ ] The four alarm limits, LOW, HIGH, LOLO and HIHI, should be visible in the tooltip shown for the alarm in the alarm tree.
- [ ] Any change to these values, for example by doing a caput should be reflected on the tooltip.

### Pre-requisites
These steps must be done before the tests are performed.
1. Download the ISIS_CSS_TOP from [CSS-STUDIO](https://github.com/ISISComputingGroup/isis_css_top)
2. cd into cs-studio and switch branch to this branch and pull.
3. cd back into the top level and run build.bat to build the CSS. This can take 40 minutes or more, take a coffee break.
4. Once successfully built, open 7zip and browse within 7zip to isis_css_top\cs-studio\applications\alarm\alarm-plugins\org.csstudio.alarm.beast\target
5. Open the jar org.csstudio.alarm.beast-4.5.0-SNAPSHOT.jar and browse further into \org\csstudio\alarm\beast\client\
6. Open another instance of 7Zip and browse to \Instrument\Dev\ibex_gui\built_client\plugins
7. Open the jar org.csstudio.alarm.beast_4.5.0.202504161924.jar and browse further into \org\csstudio\alarm\beast\client\
8. Copy or drag drop these files from the first instance of 7Zip to the second instance: AlarmTreePV.class, AlarmTreePV$PV.class,  AlarmTreePV$PV$1.class and AlarmTreePV$PV$1$1.class
9. In the first instance of 7Zip browse back to META-INF folder within the jar and copy the line org.diirt.datasource;bundle-version="3.1.8" from the Require-Bundle section of the METAINF.MF file into the corresponding file in the second instance. However in the second file check the version against the entry for org.diirt.util and maintain the same version for org.diirt.datasource
11. While on the same path, on the second instance of 7Zip browse to maven\org.csstudio\org.csstudio.alarm.beast\ and open pom.xml
12. search org.diirt.util and add an entry for org.diirt.datasource like this
```
    <dependency>
      <groupId>p2.eclipse.plugin</groupId>
      <artifactId>org.diirt.datasource</artifactId>
      <version>3.1.8.20250416192317</version>
      <type>eclipse-plugin</type>
      <scope>provided</scope>
      <optional>true</optional>
    </dependency>
```
change the version to whatever you see for org.diirt.util 

### To test
1. Open IBEX from the \Instrument\Dev\ibex_gui\built_client
2. Click on the Alarm tab
3. Expand the alarm tree and hover the mouse over a PV
4. Check the details in the tooltip. The HIHI, LOLO, LOW, HIGH values should be visible.
5. On an Epics terminal, execute caget pv.HIHI (and .LOLO, .LOW, .HIGH) and verify against the values shown in the tooltip in step 4
6. On the epics terminal, execute caput pv.HIHI 50
7. Repeat steps 1-4. The new values should be shown in the tooltip.


---

#### Code Review

- [ ] Is the code of an acceptable quality?


