### PR TITLE
code changes to identify thread_pool for alarms

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.junit;bundle-version="4.8.2",
  org.csstudio.logging;bundle-version="3.1.0",
  org.csstudio.security;bundle-version="1.0.0",
  org.diirt.util;bundle-version="3.1.2",
- org.diirt.vtype;bundle-version="3.1.2"
+ org.diirt.vtype;bundle-version="3.1.2",
+ org.apache.commons.lang3
 Export-Package: org.csstudio.alarm.beast,
  org.csstudio.alarm.beast.client,
  org.csstudio.alarm.beast.ui.clientmodel

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.beast/src/org/csstudio/alarm/beast/client/AlarmTreePV.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 
 
 /** Leaf item in the alarm configuration tree which refers to a PV,
@@ -63,7 +64,8 @@ public class AlarmTreePV extends AlarmTreeLeaf
     /**
      * Thread pool for Alarms limit PV info.
      */
-    private static final ExecutorService PVINFO_THREADPOOL = Executors.newCachedThreadPool();
+    private static final ExecutorService PVINFO_THREADPOOL = Executors.newCachedThreadPool(
+    		new BasicThreadFactory.Builder().namingPattern("AlarmTreePV_LimitsInfo-threadpool-%d").build());
     
 	/**
 	 * Thread-safe PV reader for the limit PVs. For each interesting PV limit an
@@ -89,9 +91,6 @@ public class AlarmTreePV extends AlarmTreeLeaf
             Future<?> result = PVINFO_THREADPOOL.submit(new Runnable() {
     			@Override
     			public void run() {
-    				// Set the thread name for easier debugging. Not using custom factory because 
-    				// there is no easy way to set the PV name in a custom factory (eg allows thread count).
-    				Thread.currentThread().setName(String.format("AlarmTreePV_PVInfo-%s", pvName));
     				listener = new PVReaderListener<VType>() {
     					@Override
     					public synchronized void pvChanged(PVReaderEvent<VType> evt) {


### PR DESCRIPTION
This is a follow up from the comment on identifying the thread pool for [PR](https://github.com/ISISComputingGroup/cs-studio/pull/18)